### PR TITLE
Fixed a trivial typo in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,7 +198,7 @@ The res object will be empty
 ```js
 app.use(
   logger({
-    reqUnselect: ['header.cookies', 'header.user-agent'],
+    reqUnselect: ['header.cookie', 'header.user-agent'],
   })
 );
 ```


### PR DESCRIPTION
`header.cookies` should be `header.cookie` (no `s`)
