### PR TITLE
fix req body logging since additionalProperties: { type: 'string' } allows additional properties but requires them to be of type string (or whatever type you specify).

### DIFF
--- a/stringify_schema.js
+++ b/stringify_schema.js
@@ -35,7 +35,7 @@ const defaultSchemas = {
       href: { type: 'string' },
       body: {
         type: 'object',
-        additionalProperties: { type: 'string' },
+        additionalProperties: true,
       },
       query: {
         type: 'object',


### PR DESCRIPTION
This PR fixes https://github.com/yidinghan/koa2-winston/issues/36